### PR TITLE
Update GNOME runtime to version 46

### DIFF
--- a/io.github.quodlibet.QuodLibet.yaml
+++ b/io.github.quodlibet.QuodLibet.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.quodlibet.QuodLibet
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: quodlibet
 build-options:


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.